### PR TITLE
Fix forms.update documentation and link

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ Each one of them encapsulates the operations related to it (like listing, updati
 - Returns a typeform with the payload [referenced here](https://developer.typeform.com/create/reference/retrieve-form/).
 
 #### `forms.update({ uid, data = {}, override = false })`
-- Get a typeform by UID
-- Returns a typeform with the payload [referenced here](https://developer.typeform.com/create/reference/retrieve-form/).
+- Update a typeform by UID
+- Returns a typeform with the payload [referenced here](https://developer.typeform.com/create/reference/update-form/).
 
 #### `forms.delete({ uid })`
 


### PR DESCRIPTION
Previous documentation had information for `forms.get`