### PR TITLE
Update package.json - Typo in Homepage URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "bugs": {
     "url": "https://github.com/Typeform/js-api-client/issues"
   },
-  "homepage": "https://github.com/Typeform/js-api-clientk#readme",
+  "homepage": "https://github.com/Typeform/js-api-client#readme",
   "dependencies": {
     "isomorphic-fetch": "^2.2.1"
   },


### PR DESCRIPTION
While browsing on NPM, I realized the homepage URL had a typo.

Here is a fix to it.