### PR TITLE
feat(create-client): remove need for token

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,7 @@ npm install @typeform/api-client --save
 2. Create an instance with your personal token
 
 ``` javascript
-  const typeformAPI = createClient({
-    token: '<your token>'
-  })
+  const typeformAPI = createClient({ token: '<your token>' })
 ```
 
 3. Use any of the methods available in the [reference](#reference)
@@ -75,9 +73,10 @@ npm install @typeform/api-client --save
 - Returns an instance with the methods described below
 
 ``` javascript
-  const typeformClient = createClient({
-    token: '<your token>'
-  })
+  const typeformClient = createClient({ token: '<your token>' })
+
+  // If what you are trying to acces doesn't require a token, you can construct the client without any argument
+  const typeformAPI = createClient()
 ```
 
 Client returns the following properties:

--- a/src/create-client.ts
+++ b/src/create-client.ts
@@ -2,7 +2,7 @@ import axios from 'axios'
 import { API_BASE_URL } from './constants'
 import { Typeform } from './typeform-types'
 
-export const clientConstructor = ({ token, ...options }: Typeform.ClientArg): Typeform.HTTPClient => {
+export const clientConstructor = ({ token, ...options }: Typeform.ClientArg = {}): Typeform.HTTPClient => {
   return {
     request: (args: Typeform.Request) => {
       const {
@@ -15,14 +15,9 @@ export const clientConstructor = ({ token, ...options }: Typeform.ClientArg): Ty
 
       const requestUrl = buildUrlWithParams(`${API_BASE_URL}${url}`, params)
 
-      const {
-        headers = {}
-      } = options
-
-      const requestParameters = {
-        ...options,
-        ...otherArgs
-      }
+      const { headers = {} } = options
+      const authorization = token ? { Authorization: `bearer ${token}` } : {}
+      const requestParameters = { ...options, ...otherArgs }
 
       // @ts-ignore
       return axios({
@@ -33,7 +28,7 @@ export const clientConstructor = ({ token, ...options }: Typeform.ClientArg): Ty
           Accept: 'application/json, text/plain, */*',
           ...headers,
           ...argsHeaders,
-          Authorization: `bearer ${token}`
+          ...authorization
         }
       })
         .then((response: any) => response.data)

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,10 +11,6 @@ import { Typeform } from './typeform-types'
 export { Typeform } from './typeform-types'
 
 export const createClient = (args: Typeform.ClientArg = { token: null }) => {
-  if (!args.token) {
-    throw new Error('Token is missing')
-  }
-
   const http = clientConstructor(args)
 
   return {

--- a/src/typeform-types.ts
+++ b/src/typeform-types.ts
@@ -156,7 +156,7 @@ export namespace Typeform {
    * Argument object for Typeform API client
    */
   export interface ClientArg extends DocumentData {
-    token: string
+    token?: string
   }
   /**
    * Conditions for executing the Logic Jump. Conditions answer the question, "Under what circumstances?"

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -14,6 +14,6 @@ test('client constructor has a request function property', () => {
   expect(client.request).toBeDefined()
 })
 
-test('Initialising fails when missing the token', () => {
-  expect(() => createClient()).toThrow('Token is missing')
+test('Initialising does not fail when missing the token', () => {
+  expect(() => createClient()).not.toThrow()
 })


### PR DESCRIPTION
Removes need for passing in token when constructing client, that way simple tasks like fetching public forms are easy. If a request requires a token, then the request would fail and the user would need to `catch` the failed request (which usually says a token is needed).