### PR TITLE
fix(NOJIRA-123): fix Action.condition type

### DIFF
--- a/src/typeform-types.ts
+++ b/src/typeform-types.ts
@@ -16,7 +16,7 @@ export namespace Typeform {
      * Conditions for executing the Logic Jump. Conditions answer the question, "Under what circumstances?"
      * The condition object is the IF statement in your Logic Jump.
      */
-    condition?: Condition
+    condition?: Condition | AndOrOperator
   }
   /**
    * Properties that further specify how the Logic Jump will behave.
@@ -197,6 +197,19 @@ export namespace Typeform {
        */
       value?: any
     }[]
+  }
+  /**
+   * Conditions for a logic jump can be combined using the `and` and `or` operators
+   */
+  export interface AndOrOperator {
+  /**
+   * Operator for the condition.
+   */
+    op?: 'and' | 'or'
+  /**
+   * Object that defines the field type and value to evaluate with the operator.
+   */
+    vars: AndOrOperator[] | Condition[]
   }
   /**
    * Generic document.

--- a/src/typeform-types.ts
+++ b/src/typeform-types.ts
@@ -209,7 +209,7 @@ export namespace Typeform {
   /**
    * Object that defines the field type and value to evaluate with the operator.
    */
-    vars: AndOrOperator[] | Condition[]
+    vars: Array<AndOrOperator | Condition>
   }
   /**
    * Generic document.


### PR DESCRIPTION
The Create API allows for the logical operators 'and' and 'or' to be used to combine conditions for an action. This change updates the types to include an `AndOrOperator` type to reflect that.

https://developer.typeform.com/create/logic-jumps/#best-practices-for-logic-jumps

