### PR TITLE
fix(types): fix Condition.op type

### DIFF
--- a/src/typeform-types.ts
+++ b/src/typeform-types.ts
@@ -166,7 +166,7 @@ export namespace Typeform {
     /**
      * Operator for the condition.
      */
-    op?: 'begins_with' | 'ends_with' | 'contains' | 'not_contains' | 'lower_than' | 'lower_equal_than' | 'greater_than'
+    op?: 'starts_with' | 'ends_with' | 'contains' | 'not_contains' | 'lower_than' | 'lower_equal_than' | 'greater_than'
     | 'greater_equal_than' | 'is' | 'is_not' | 'equal' | 'not_equal' | 'always' | 'on' | 'not_on' | 'earlier_than' | 'earlier_than_or_on'
     | 'later_than' | 'later_than_or_on'
     /**


### PR DESCRIPTION
The operator `begins_with` should be `starts_with` per the docs
https://developer.typeform.com/create/logic-jumps/
