### PR TITLE
fix(types): fix Condition variable `type` property

### DIFF
--- a/src/typeform-types.ts
+++ b/src/typeform-types.ts
@@ -176,7 +176,7 @@ export namespace Typeform {
       /**
        * Type of value the condition object refers to.
        */
-      type?: 'field' | 'hidden' | 'variable' | 'constant' | 'end'
+      type?: 'field' | 'hidden' | 'variable' | 'constant' | 'end'| 'choice'
       /**
        * Value to check for in the "type" field to evaluate with the operator.
        */


### PR DESCRIPTION
When I retrieve a form from Typeform I notice that some of my condition variables have the value `'choice'` as the type, i.e.

```
                            {
                                "op": "is",
                                "vars": [
                                    {
                                        "type": "field",
                                        "value": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
                                    },
                                    {
                                        "type": "choice",
                                        "value": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"                                    }
                                ]
                            },
```

The value `'choice'` doesn't appear to be listed in the docs Create API docs:

https://developer.typeform.com/create/reference/create-form/

If i've misunderstood, feel free to close this PR. Otherwise, this PR adds the value `'choice'` to the Condition var `type` property.
