### PR TITLE
fix: introduce shared travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 version: ~> 1.0
-import: Typeform/travis-shared-config:package-config.yml@master
+import: Typeform/travis-shared-config:public-package-config.yml@master
 
 language: node_js
 node_js:
-  - "12"
+  - '12'
 
 branches:
   only:
@@ -17,7 +17,7 @@ notifications:
   email: false
 
 env:
-  VERSION: "$TRAVIS_BUILD_NUMBER"
+  VERSION: '$TRAVIS_BUILD_NUMBER'
 
 before_install:
   - yarn
@@ -32,4 +32,3 @@ script:
 
 after_success:
   - yarn semantic-release
-  

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,6 @@ script:
 
 after_success:
   - yarn run semantic-release
-  - npm config set '//npm.pkg.github.com/:_authToken' ${GH_TOKEN}
+  - npm config set '//npm.pkg.github.com/:_authToken' $GH_TOKEN
   - npm config set registry https://npm.pkg.github.com/@typeform
-  - test $TRAVIS_EVENT_TYPE = "push" && test $TRAVIS_BRANCH = "master" && echo "It did not work!"
+  - echo "Hello" && test $TRAVIS_EVENT_TYPE = "push" && test $TRAVIS_BRANCH = "master" && echo "It did not work!"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,3 @@
-version: ~> 1.0
-import: Typeform/travis-shared-config:public-package-config.yml@master
-
 language: node_js
 node_js:
   - '12'
@@ -31,4 +28,7 @@ script:
   - yarn test:integration
 
 after_success:
-  - yarn semantic-release
+  - yarn run semantic-release
+  - npm config set '//npm.pkg.github.com/:_authToken' ${GH_TOKEN}
+  - npm config set registry https://npm.pkg.github.com/@typeform
+  - test $TRAVIS_EVENT_TYPE = "push" && test $TRAVIS_BRANCH = "master" && echo "It did not work!"

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,4 +31,4 @@ after_success:
   - yarn run semantic-release
   - npm config set '//npm.pkg.github.com/:_authToken' $GH_TOKEN
   - npm config set registry https://npm.pkg.github.com/@typeform
-  - echo "Hello" && test $TRAVIS_EVENT_TYPE = "push" && test $TRAVIS_BRANCH = "master" && echo "It did not work!"
+  - test $TRAVIS_EVENT_TYPE = "push" && test $TRAVIS_BRANCH = "master" && npm publish


### PR DESCRIPTION
## DO NOT MERGE

This PR should makes `.travis.yml` to use shared config that enables publishing of npm packages to both registries: npm and github.