### PR TITLE
fix(types): fix button_text from boolean to string type

### DIFF
--- a/src/typeform-types.ts
+++ b/src/typeform-types.ts
@@ -790,7 +790,7 @@ export namespace Typeform {
       /**
        * Text to display on the 'Submit' button on the thank you screen.
        */
-      button_text?: boolean
+      button_text?: string
       /**
        * Specify whether the form should reload or redirect to another URL when respondents click the 'Submit' button. PRO+ feature.
        */
@@ -817,7 +817,7 @@ export namespace Typeform {
       /**
        * Text to display on the 'Start' button on the welcome screen.
        */
-      button_text?: boolean
+      button_text?: string
     }
   }
   /**


### PR DESCRIPTION
<!-- For fixing bugs use https://github.com/Typeform/js-api-client/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/Typeform/js-api-client/compare/?template=features.md -->

**Description of the Issue** - When creating a form and adding a button_text for the welcome screen, the type of the `button_text` is a boolean, but should be a string
![image](https://user-images.githubusercontent.com/28765290/114563733-ad568a00-9c3d-11eb-8ff2-3cdfff9db327.png)

**Motivation for or Use Case** - I want to create a form and have a custom button_text, rather than the default `Continue`
**Environment Configuration** - no
**Reproduce the Error** - screenshot above

`button_text`, is a string but currently is a `boolean` in the interface for the WelcomeScreen and ThankYouScreen. Changing this would allow users to submit their own string for the button_text