### PR TITLE
fix: update codeowners wth  partnership team name

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 * @Typeform/developer-relations
-* @Typeform/atlantis
+* @Typeform/partnerships

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typeform/api-client",
-  "version": "0.0.0",
+  "version": "0.0.0-semantic-released",
   "description": "JS SDK for Typeform API",
   "scripts": {
     "test:unit": "jest ./tests/unit",


### PR DESCRIPTION
Change Codeowners to include @Typeform/partnerships instead of @typeform/atlantis