### PR TITLE
feat(NOJIRA-123): Add Webhook toggle funcion

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,13 @@ Each one of them encapsulates the operations related to it (like listing, updati
 - `secret`: If specified, will be used to sign the webhook payload with HMAC SHA256, so that you can verify that it came from Typeform.
 - `verifySSL`: `true` if you want Typeform to verify SSL certificates when delivering payloads.
 
+#### `webhooks.toggle({ uid, tag, enabled })`
+
+- Turn on or off a webhook.
+- `uid`: Unique ID for the form.
+- `tag`: tag of the webhook created.
+- `enabled`: `true` or `false`.
+
 ## Examples
 
 ### Update specific typeform property, as [referenced here](https://developer.typeform.com/create/reference/update-form-patch/)

--- a/src/webhooks.ts
+++ b/src/webhooks.ts
@@ -40,6 +40,18 @@ export class Webhooks {
       url: `/forms/${uid}/webhooks`,
     })
   }
+  
+  public toggle (args: { uid: string, tag: string, enabled: boolean }): Promise<Typeform.API.Webhooks.List> {
+    const { uid, tag, enabled } = args
+
+    return this._http.request({
+      method: 'put',
+      url: `/forms/${uid}/webhooks/${tag}`,
+      data: {
+        enabled
+      }
+    })
+  }
 
   update(args: {
     uid: string

--- a/tests/unit/webhooks.test.ts
+++ b/tests/unit/webhooks.test.ts
@@ -63,3 +63,19 @@ test('Delete a webhook has the correct path and method', async () => {
   )
   expect(axios.history.delete[0].method).toBe('delete')
 })
+
+test('toggle(false) Disable a webhook', async () => {
+  await webhooksRequest.toggle({ uid: '2', tag: 'test', enabled: false })
+  const bodyParsed = JSON.parse(axios.history.put[0].data)
+  expect(axios.history.put[0].method).toBe('put')
+  expect(axios.history.put[0].url).toBe(`${API_BASE_URL}/forms/2/webhooks/test`)
+  expect(bodyParsed.enabled).toBe(false)
+})
+
+test('toggle(true) Enable a webhook', async () => {
+  await webhooksRequest.toggle({ uid: '2', tag: 'test', enabled: true })
+  const bodyParsed = JSON.parse(axios.history.put[0].data)
+  expect(axios.history.put[0].method).toBe('put')
+  expect(axios.history.put[0].url).toBe(`${API_BASE_URL}/forms/2/webhooks/test`)
+  expect(bodyParsed.enabled).toBe(true)
+})


### PR DESCRIPTION
I often need to change the state of a webhook.
The `update` function forces you to pass the URL pointing to the webhook.

`toggle` just turns on or off a webhook.
