### PR TITLE
Better error log

### DIFF
--- a/src/create-client.ts
+++ b/src/create-client.ts
@@ -35,8 +35,8 @@ export const clientConstructor = ({ token, ...options }: Typeform.ClientArg = {}
       })
         .then((response: any) => response.data)
         .catch((error: any) => {
-          if (error && error.response && error.response.data && error.response.data.description) {
-            throw new Error(error.response.data.description)
+          if (error && error.response && error.response.data) {
+            throw new Error(error.response.data)
           } else {
             throw new Error('Couldn\'t make request')
           }


### PR DESCRIPTION
The current implementation hides the `details` field of the error.  
This PR fixes the limitation by building the error from `details` instead of `details.description`.