### PR TITLE
chore(REACH-472): add ci-standard-checks workflow

### DIFF
--- a/.github/workflows/ci-standard-checks.yml
+++ b/.github/workflows/ci-standard-checks.yml
@@ -1,0 +1,24 @@
+name: CI Standard Checks
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches:
+      - master
+
+jobs:
+  ci-standard-checks:
+    runs-on: [ubuntu-latest]
+
+    steps:
+      - name: Check Out Source Code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: CI Standard Checks
+        uses: Typeform/ci-standard-checks@v1
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### What

Add ci-standard-checks workflow to improve standards adoption.