### PR TITLE
feat(PR-40): throw custom error

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -1,6 +1,6 @@
 import { inspect } from 'util'
 
-import { createClient } from './index'
+import { createClient, Typeform } from './index'
 
 const print = (message: string) => {
   // eslint-disable-next-line no-console
@@ -57,6 +57,14 @@ typeformAPI[property][method](parsedParams)
   .then((result: Object) => {
     print(inspect(result, { showHidden: false, depth: null, colors: true }))
   })
-  .catch((err: Error) => {
-    print(`Error: ${err.message}`)
+  .catch((err: Typeform.ApiError) => {
+    const detailsString = inspect(err.details, {
+      showHidden: false,
+      depth: null,
+      colors: true,
+    })
+    print(`---------------------------------------------`)
+    print(`Error: ${err.code}: ${err.message}`)
+    print(`Details: ${detailsString}`)
+    print(`---------------------------------------------`)
   })

--- a/src/create-client.ts
+++ b/src/create-client.ts
@@ -27,7 +27,6 @@ export const clientConstructor = ({
       const authorization = token ? { Authorization: `bearer ${token}` } : {}
       const requestParameters = { ...options, ...otherArgs }
 
-      // @ts-ignore
       return axios({
         url: requestUrl,
         ...requestParameters,
@@ -41,16 +40,12 @@ export const clientConstructor = ({
       })
         .then((response) => response.data)
         .catch((error) => {
-          if (
-            error &&
-            error.response &&
-            error.response.data &&
-            error.response.data.description
-          ) {
-            throw new Error(error.response.data.description)
-          } else {
-            throw new Error("Couldn't make request")
-          }
+          const {
+            code,
+            description = "Couldn't make request",
+            details,
+          } = error?.response?.data || {}
+          throw new Typeform.ApiError(code, description, details)
         })
     },
   }

--- a/src/typeform-types.ts
+++ b/src/typeform-types.ts
@@ -201,7 +201,7 @@ export namespace Typeform {
       /**
        * Type of value the condition object refers to.
        */
-      type?: 'field' | 'hidden' | 'variable' | 'constant' | 'end'| 'choice'
+      type?: 'field' | 'hidden' | 'variable' | 'constant' | 'end' | 'choice'
       /**
        * Value to check for in the "type" field to evaluate with the operator.
        */
@@ -212,13 +212,13 @@ export namespace Typeform {
    * Conditions for a logic jump can be combined using the `and` and `or` operators
    */
   export interface AndOrOperator {
-  /**
-   * Operator for the condition.
-   */
+    /**
+     * Operator for the condition.
+     */
     op?: 'and' | 'or'
-  /**
-   * Object that defines the field type and value to evaluate with the operator.
-   */
+    /**
+     * Object that defines the field type and value to evaluate with the operator.
+     */
     vars: Array<AndOrOperator | Condition>
   }
   /**
@@ -1377,5 +1377,15 @@ export namespace Typeform {
       email: string
       role: 'owner' | 'member'
     }[]
+  }
+  export class ApiError extends Error {
+    code: string
+    details: Object[]
+
+    constructor(code: string, message: string, details: Object[]) {
+      super(message)
+      this.code = code
+      this.details = details
+    }
   }
 }


### PR DESCRIPTION
Use custom `Typeform.ApiError` class to throw error with more details.

Resolves #56