### PR TITLE
docs(badges): add standard badges to README [PR-41]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<a href=https://engineering-metrics.typeform.tf/standards-adoption-tool/reports/js-api-client/><img src=https://api.typeform.com/repositories/js-api-client/badges.svg /></a>
 # Typeform JavaScript SDK
 
 [![Pull Request](https://github.com/Typeform/js-api-client/actions/workflows/pr.yml/badge.svg)](https://github.com/Typeform/js-api-client/actions/workflows/pr.yml)


### PR DESCRIPTION
Add new badges img to repository

[_Created by Sourcegraph batch change `engineering-intelligence/PR-41-update-repo-badges-img-no-previous-badge`._](https://sourcegraph.tools.typeform.tf/users/engineering-intelligence/batch-changes/PR-41-update-repo-badges-img-no-previous-badge)