### PR TITLE
feat(NOJIRA-123): Patch type improvements

### DIFF
--- a/src/forms.ts
+++ b/src/forms.ts
@@ -73,11 +73,23 @@ export class Forms {
     return request(page, pageSize)
   }
 
-  public update(args: {
+  public update<T extends boolean>(args: {
     uid: string
-    override?: boolean
-    data: Typeform.Form
-  }): Promise<Typeform.Form> {
+    override?: T
+    data: T extends true
+      ? Typeform.Form
+      : Typeform.API.PATCH<
+          | '/settings/facebook_pixel'
+          | '/settings/google_analytics'
+          | '/settings/google_tag_manager'
+          | '/settings/is_public'
+          | '/settings/meta'
+          | '/cui_settings'
+          | '/theme'
+          | '/title'
+          | '/workspace'
+        >[]
+  }): Promise<T extends true ? Typeform.Form : null> {
     const { uid, override, data } = args
     const methodType = override ? 'put' : 'patch'
 

--- a/src/typeform-types.ts
+++ b/src/typeform-types.ts
@@ -113,9 +113,9 @@ export namespace Typeform {
         items: Workspace[]
       }
     }
-    export interface PATCH {
-      op: string
-      path: string
+    export interface PATCH<T extends string> {
+      op: 'add' | 'remove' | 'replace'
+      path: T
       value: any
     }
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,8 +2,8 @@ import { Typeform } from './typeform-types'
 
 export const createMemberPatchQuery = (
   members: string[],
-  operation: string
-): Typeform.API.PATCH[] => {
+  operation: Typeform.API.PATCH<'/members'>['op']
+): Typeform.API.PATCH<'/members'>[] => {
   return members.map((member) => ({
     op: operation,
     path: '/members',

--- a/src/workspaces.ts
+++ b/src/workspaces.ts
@@ -93,7 +93,7 @@ export class Workspaces {
 
   public update(args: {
     id: string
-    data: Typeform.API.PATCH[]
+    data: Typeform.API.PATCH<'/name' | '/members'>[]
   }): Promise<null> {
     const { id, data } = args
 
@@ -109,9 +109,9 @@ export class Workspaces {
 }
 
 const addOrRemoveMembers = (
-  operation: string,
+  operation: Typeform.API.PATCH<'/members'>['op'],
   members: string | string[]
-): Typeform.API.PATCH[] => {
+): Typeform.API.PATCH<'/members'>[] => {
   if (!isMemberPropValid(members)) {
     throw new Error(`No member(s) provided`)
   }


### PR DESCRIPTION
The main goal of this PR was to fix up the type for `form.update` to allow patch updates. The current type definition only allows `data`  to be of type `Typeform.Form` which doesn't match the input required for `PATCH` operations. In the process of making the fix, I also made the following improvements to the `PATCH` type: 

1. Changed the type of `op` to a static list of operations currently supported by Typeform. I intentionally didn't add all of the [operations](https://jsonpatch.com/#operations) supported in JSON Patch as it does not seem the Typeform API supports all of those operations. 
2. I made the `PATCH` have a static list of paths depending on the endpoint. This one is definitely good for completion in editors, but does introduce a maintenance burden on the SDK as the list would need to be updated whenever the Typeform API is updated. 

Happy to make any changes / remove improvements as you all see fit :) 