### PR TITLE
feat(type): update form.settings type to have all options

### DIFF
--- a/src/typeform-types.ts
+++ b/src/typeform-types.ts
@@ -1067,37 +1067,46 @@ export namespace Typeform {
    */
   export interface Settings {
     /**
-     * Language of form.
+     * Default: `false`
      */
-    language?: Language
+    are_uploads_public?: boolean
+
     /**
-     * Default: `""`
+     * Default: `true`
+     * true to enable saving partial form responses on the client side. Otherwise, false.
+     */
+    autosave_progress?: boolean
+
+    /**
+     * Default: `false`
+     * Allow people to navigate freely between the questions of your Typeform. They will still have to answer the required ones before submitting.
+     */
+    free_form_navigation?: boolean
+
+    /**
+     * Default: `false`
+     * false to display the navigation arrows in the bottom-right corner of the form, true to hide them
+     */
+    hide_navigation?: boolean
+
+    /**
+     * Default: `true`
      * true if your form is public. Otherwise, false (your form is private).
      */
     is_public?: boolean
+
     /**
-     * Default: `"proportion"`
-     * Basis for the progress bar displayed on the screen. Choose "proportion" to show the number of questions answered so far.
-     * Choose "percentage" to show the percentage of questions answered so far.
+     * Language of form.
      */
-    progress_bar?: 'percentage' | 'proportion'
-    /**
-     * Default: `""`
-     * true to display progress bar on the typeform. Otherwise, false.
-     */
-    show_progress_bar?: boolean
-    /**
-     * Default: `""`
-     * true to display Typeform brand on the typeform. false to hide Typeform branding on the typeform.
-     * Hiding Typeform branding is available for PRO+ accounts.
-     */
-    show_typeform_branding?: boolean
+    language?: Language
+
     meta?: {
       /**
-       * Default: `""`
+       * Default: `false`
        * true to allow search engines to index your typeform. Otherwise, false.
        */
       allow_indexing?: boolean
+
       /**
        * Description for search engines to display for your typeform.
        */
@@ -1109,6 +1118,67 @@ export namespace Typeform {
         href?: string
       }
     }
+
+    /**
+     * Default: `false`
+     */
+    pro_subdomain_enabled?: boolean
+
+    /**
+     * Default: `"proportion"`
+     * Basis for the progress bar displayed on the screen. Choose "proportion" to show the number of questions answered so far.
+     * Choose "percentage" to show the percentage of questions answered so far.
+     */
+    progress_bar?: 'percentage' | 'proportion'
+
+    /**
+     * Default: `false`
+     * true to request cookie consent to respondents through a banner, false to do not request it.
+     */
+    show_cookie_consent?: boolean
+
+    /**
+     * Default: `true`
+     * true to display the key hint letters on Multiple Choice, Picture Choice, Legal and Yes/No blocks, false to hide them.
+     */
+    show_key_hint_on_choices?: boolean
+
+    /**
+     * Default: `false`
+     * true to display number of submissions on Welcome screens, false to hide it. Mutually exclusive with show_time_to_complete
+     */
+    show_number_of_submissions?: boolean
+
+    /**
+     * Default: `true`
+     * true to display progress bar on the typeform. Otherwise, false.
+     */
+    show_progress_bar?: boolean
+
+    /**
+     * Default: `true`
+     * true to display the question number on each block, false to hide it.
+     */
+    show_question_number?: boolean
+
+    /**
+     * Default: `true`
+     * true to display estimated time to complete a typeform on Welcome screens, false to hide it. Mutually exclusive with show_number_of_submissions
+     */
+    show_time_to_complete?: boolean
+
+    /**
+     * Default: `true`
+     * true to display Typeform brand on the typeform. false to hide Typeform branding on the typeform.
+     * Hiding Typeform branding is available for PRO+ accounts.
+     */
+    show_typeform_branding?: boolean
+
+    /**
+     * Default: `false`
+     */
+    use_lead_qualification?: boolean
+
     /**
      * URL where the typeform should redirect upon submission.
      */


### PR DESCRIPTION
I got the list of defaults by creating a new form using the API and inspecting the response as some of the options were not listed on the docs / had different names vs what was specified on the docs.

I also reordered the options to match the API response order.

Added:
- are_uploads_public
- autosave_progress (docs have this as `autocomplete_progress`)
- free_form_navigation
- hide_navigation
- pro_subdomain_enabled
- show_cookie_consent
- show_key_hint_on_choices
- show_number_of_submissions
- show_question_number
- show_time_to_complete
- use_lead_qualification

Reordered:
- language
- is_public
- progress_bar
- show_progress_bar
- show_typeform_branding
