### PR TITLE
feat: export http client constructor

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { Typeform } from './typeform-types'
 import { Insights } from './insights'
 
 export { Typeform } from './typeform-types'
+export { clientConstructor } from './create-client'
 
 export const createClient = (args: Typeform.ClientArg = { token: null }) => {
   const http = clientConstructor(args)


### PR DESCRIPTION
Export the `clientConstructor` to allow wrapping the client (and extending it).

https://typeform.atlassian.net/browse/PLT-1549