### PR TITLE
build: upgrade axios to 1.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "yarn.lock"
   ],
   "dependencies": {
-    "axios": "^1.7.8"
+    "axios": "^1.8.2"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3528,10 +3528,10 @@ axios-mock-adapter@^1.22.0:
     fast-deep-equal "^3.1.3"
     is-buffer "^2.0.5"
 
-axios@^1.7.8:
-  version "1.7.8"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.8.tgz#1997b1496b394c21953e68c14aaa51b7b5de3d6e"
-  integrity sha512-Uu0wb7KNqK2t5K+YQyVCLM76prD5sRFjKHbJYCP1J7JFGEQ6nN7HWn9+04LAeiJ3ji54lgS/gZCH1oxyrf1SPw==
+axios@^1.8.2:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.10.0.tgz#af320aee8632eaf2a400b6a1979fa75856f38d54"
+  integrity sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==
   dependencies:
     follow-redirects "^1.15.6"
     form-data "^4.0.0"


### PR DESCRIPTION
There is a Server-side Request Forgery (SSRF) vulnerability in Axios version 1.7.8. This was fixed in version 1.8.2.

<!-- For fixing bugs use https://github.com/Typeform/js-api-client/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/Typeform/js-api-client/compare/?template=features.md -->
