### PR TITLE
  Fix CI Standard Checks timeout due to runner restrictions

### DIFF
--- a/.github/workflows/ci-standard-checks.yml
+++ b/.github/workflows/ci-standard-checks.yml
@@ -15,3 +15,5 @@ on:
 jobs:
   ci-standard-checks:
     uses: Typeform/.github/.github/workflows/ci-standard-checks-workflow.yaml@v1
+    with:
+      runner: ubuntu-latest


### PR DESCRIPTION
## Problem

CI Standard Checks workflow has been timing out after 24 hours since March 27. The reusable workflow defaults to `ci-base-scale-set` (self-hosted runners), but these are restricted to private repos. Public repos like `js-api-client` can't access them, causing jobs to queue  indefinitely until auto-cancelled.
This pull request makes a configuration update to the GitHub Actions workflow. The change explicitly specifies the runner environment for the `ci-standard-checks` job.
## Changes

- Updated .github/workflows/ci-standard-checks.yml to specify runner: ubuntu-latest