### PR TITLE
chore: Migrate dependabot workflow to scale-set runner

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   dependabot:
-    runs-on: [self-hosted, ci-universal]
+    runs-on: [ci-universal-scale-set]
     if: github.actor == 'dependabot[bot]'
 
     steps:


### PR DESCRIPTION
## Summary
- Migrate dependabot-automerge workflow from legacy `ci-universal` runner to `ci-universal-scale-set`

## Changes
- Update `.github/workflows/dependabot-automerge.yml` to use `ci-universal-scale-set` runner

## Context
Part of the GitHub Actions runner migration from legacy ephemeral runners to the new scale-set architecture. This fixes the issue where dependabot PRs were stuck waiting for unavailable `ci-universal` runners.

Related: PLT-3366

🤖 Generated with [Claude Code](https://claude.com/claude-code)