### PR TITLE
fix: Use ubuntu-latest for dependabot workflow security

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   dependabot:
-    runs-on: [ci-universal-scale-set]
+    runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
 
     steps:


### PR DESCRIPTION
## Summary
- Update dependabot-automerge workflow to use GitHub-hosted runners (ubuntu-latest)

## Changes
- Update `.github/workflows/dependabot-automerge.yml` to use `ubuntu-latest` instead of `ci-universal-scale-set`

## Context
The `ci-universal-scale-set` runners are not accessible to this repository (stuck in queue), causing dependabot PRs to wait indefinitely. 

Using GitHub-hosted runners (ubuntu-latest) provides:
- Better security for `pull_request_target` workflows
- Ephemeral, isolated environments
- No runner group configuration needed
- Guaranteed availability

This workflow only approves/merges dependabot PRs and doesn't execute PR code, making GitHub-hosted runners the safest choice.

Related: PLT-3366

🤖 Generated with [Claude Code](https://claude.com/claude-code)