### PR TITLE
fix(NOJIRA-1234): correct dependabot cooldown configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,10 +26,13 @@ updates:
       - npm-github
       - git-github
     cooldown:
-      default:
-        days: 7
-      exclude-patterns:
-        - "@typeform/*"
+      default-days: 7
+      exclude:
+        - '@typeform/*'
+    ignore:
+      - dependency-name: semantic-release
+        versions:
+          - '>=25.0.0'
   - package-ecosystem: github-actions
     schedule:
       interval: weekly


### PR DESCRIPTION
## Dependabot Configuration Repair

This automated PR fixes an invalid schema for the `cooldown` property in `dependabot.yml`. 
The previous configuration used an unsupported nested structure (`default: days: 7`) which prevented Dependabot from parsing the file correctly.

### Changes
- Updated `cooldown` to use the official `default-days: 7` schema.
- Maintained exclusions for `@typeform/*` packages.
- Verified `semantic-release` version pins.

---
_Automated by Application Security · global-cooldown-repair_

[_Created by Sourcegraph batch change `david.salvador/fix-dependabot-cooldown-global`._](https://typeform.sourcegraphcloud.com/users/david.salvador/batch-changes/fix-dependabot-cooldown-global)