### PR TITLE
chore(PLT-3524): remove orphaned SonarCloud coverage plumbing

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         node_version:
-          - 24 # end of life 2028-04-30 # coverage file uploaded from this version
+          - 24 # end of life 2028-04-30
     name: build-lint-test - node ${{ matrix.node_version }}
     steps:
       - name: Check out Git repository
@@ -43,21 +43,8 @@ jobs:
         run: yarn lint
 
       - name: Unit tests
-        run: yarn test:unit --coverage
+        run: yarn test:unit
 
       - name: Integration tests
-        run: (yarn server &) && sleep 1 && yarn test:integration --coverage
-
-      - name: Merge coverage reports and generate lcov.info
-        run: |
-          mkdir -p .nyc_output
-          npx nyc merge ./coverage
-          npx nyc report --reporter=lcov --temp-dir ./coverage
-
-      - name: Upload coverage file
-        uses: actions/upload-artifact@v7
-        with:
-          name: coverage-report
-          path: ./coverage/lcov.info
-          retention-days: 1
+        run: (yarn server &) && sleep 1 && yarn test:integration
 


### PR DESCRIPTION
## Description
*From Glean Code Writer*

Follow-up to PR #165 — removes the coverage plumbing that was left behind after the `sonarcloud` job was deleted.

PR #165 correctly removed the SonarCloud scan job and config, but left the steps that existed only to feed it:
- The **"Merge coverage reports and generate lcov.info"** step
- The **"Upload coverage file"** step (its artifact had zero consumers)
- The `--coverage` flags on test runs (output was unused)
- A stale comment documenting the coverage upload

These were all part of the chain that generated `lcov.info` for the SonarCloud scan. With the scan gone, they're dead weight.

### Changes
- Removed `--coverage` flags from `yarn test:unit` and `yarn test:integration`
- Removed the "Merge coverage reports and generate lcov.info" step
- Removed the "Upload coverage file" step
- Cleaned up stale `# coverage file uploaded from this version` comment

Net result: the `build-lint-test` job now just runs install → build → lint → unit tests → integration tests, with no leftover Sonar artifacts.

Part of PLT-3524 SonarCloud decommission. This cleanup follows the same pattern as purgatory #306 and single-embed #286, which removed their coverage-upload steps in the initial PR.

## Testing
- Workflow syntax is valid (standard GitHub Actions)
- CI will verify standard test suite still passes

___
🤖 *Generated by Glean Code Writer*
📝 Chat link - https://app.glean.com/chat/c78bd9fcfe7a4a1d9eb95b520a8fb09f